### PR TITLE
Update windows.go so the GameAP installer works again for Windows

### DIFF
--- a/pkg/package_manager/windows.go
+++ b/pkg/package_manager/windows.go
@@ -87,8 +87,7 @@ var repository = map[string]pack{
 	PHPPackage: {
 		LookupPath: []string{"php"},
 		DownloadURLs: []string{
-			"https://windows.php.net/downloads/releases/php-8.3.3-Win32-vs16-x64.zip",
-			"https://windows.php.net/downloads/releases/php-8.2.2-Win32-vs16-x64.zip",
+			"https://windows.php.net/downloads/releases/php-8.3.4-Win32-vs16-x64.zip",
 		},
 		DefaultInstallPath: "C:\\php",
 		ServiceConfig: &WinSWServiceConfig{


### PR DESCRIPTION
The versions for php listed there arent available anymore, so i swapped the link with an up-to date one.